### PR TITLE
Adiciona parser de CSV do Nubank e inserção em banco

### DIFF
--- a/banco.php
+++ b/banco.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Insere uma transação no banco de dados SQLite.
+ *
+ * @param string $date Data no formato YYYY-MM-DD
+ * @param string $title Descrição da transação
+ * @param float $amount Valor negativo da transação
+ * @param int|null $parcelaAtual Número da parcela atual, se existir
+ * @param int|null $parcelaTotal Total de parcelas, se existir
+ */
+function insert_transaction(
+    string $date,
+    string $title,
+    float $amount,
+    ?int $parcelaAtual = null,
+    ?int $parcelaTotal = null
+): void {
+    $pdo = new PDO('sqlite:' . __DIR__ . '/nubank.db');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS transacoes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        date TEXT NOT NULL,
+        title TEXT NOT NULL,
+        amount REAL NOT NULL,
+        parcela_atual INTEGER NULL,
+        parcela_total INTEGER NULL
+    )');
+
+    $stmt = $pdo->prepare('INSERT INTO transacoes (date, title, amount, parcela_atual, parcela_total)
+        VALUES (:date, :title, :amount, :parcela_atual, :parcela_total)');
+    $stmt->execute([
+        ':date' => $date,
+        ':title' => $title,
+        ':amount' => $amount,
+        ':parcela_atual' => $parcelaAtual,
+        ':parcela_total' => $parcelaTotal,
+    ]);
+}
+
+?>

--- a/importar.php
+++ b/importar.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Lê um CSV exportado do Nubank e insere cada registro no banco de dados.
+ *
+ * Espera-se que o arquivo tenha as colunas: data, título e valor.
+ *
+ * @param string $path Caminho para o arquivo CSV.
+ * @return array Lista de registros inseridos.
+ */
+function parse_nubank_csv(string $path): array
+{
+    require_once __DIR__ . '/banco.php';
+
+    if (!file_exists($path)) {
+        throw new InvalidArgumentException("Arquivo não encontrado: {$path}");
+    }
+
+    $handle = fopen($path, 'r');
+    if ($handle === false) {
+        throw new RuntimeException("Não foi possível abrir o arquivo: {$path}");
+    }
+
+    // Ignora o cabeçalho
+    $headers = fgetcsv($handle);
+
+    $registros = [];
+    while (($row = fgetcsv($handle)) !== false) {
+        // Assume que as colunas são [data, titulo, valor]
+        $dataBruta = trim($row[0] ?? '');
+        $titulo = trim($row[1] ?? '');
+        $valorBruto = trim($row[2] ?? '0');
+
+        // Converte data para YYYY-MM-DD
+        $dataObj = \DateTime::createFromFormat('d/m/Y', $dataBruta);
+        if ($dataObj === false) {
+            // Tenta formato alternativo
+            $dataObj = new \DateTime($dataBruta);
+        }
+        $data = $dataObj->format('Y-m-d');
+
+        // Converte valor para decimal negativo
+        $valorLimpo = preg_replace('/[^0-9,.-]/', '', $valorBruto);
+        if (str_contains($valorLimpo, ',')) {
+            // Formato brasileiro: milhar com ponto e decimal com vírgula
+            $valorLimpo = str_replace(['.', ','], ['', '.'], $valorLimpo);
+        }
+        $valor = -abs((float)$valorLimpo);
+
+        // Detecta parcelas no título
+        $parcelaAtual = null;
+        $parcelaTotal = null;
+        if (preg_match('/Parcela\s+(\d+)\/(\d+)/i', $titulo, $matches)) {
+            $parcelaAtual = (int)$matches[1];
+            $parcelaTotal = (int)$matches[2];
+        }
+
+        // Insere no banco de dados
+        insert_transaction($data, $titulo, $valor, $parcelaAtual, $parcelaTotal);
+
+        $registros[] = [
+            'date' => $data,
+            'title' => $titulo,
+            'amount' => $valor,
+            'parcela_atual' => $parcelaAtual,
+            'parcela_total' => $parcelaTotal,
+        ];
+    }
+
+    fclose($handle);
+
+    return $registros;
+}
+
+?>


### PR DESCRIPTION
## Summary
- Adiciona função `parse_nubank_csv` para importar dados de CSV do Nubank
- Normaliza datas, valores e detecta parcelas nas descrições
- Cria utilitário `insert_transaction` para salvar dados em banco SQLite

## Testing
- `php -l importar.php`
- `php -l banco.php`


------
https://chatgpt.com/codex/tasks/task_e_689cb32a1e74832cb027873b76ee764d