### PR TITLE
Add category spending limits and daily check

### DIFF
--- a/banco.php
+++ b/banco.php
@@ -9,34 +9,102 @@
  * @param int|null $parcelaAtual Número da parcela atual, se existir
  * @param int|null $parcelaTotal Total de parcelas, se existir
  */
-function insert_transaction(
-    string $date,
-    string $title,
-    float $amount,
-    ?int $parcelaAtual = null,
-    ?int $parcelaTotal = null
-): void {
+function get_pdo(): PDO {
     $pdo = new PDO('sqlite:' . __DIR__ . '/nubank.db');
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
 
+function ensure_tables(PDO $pdo): void {
     $pdo->exec('CREATE TABLE IF NOT EXISTS transacoes (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         date TEXT NOT NULL,
         title TEXT NOT NULL,
         amount REAL NOT NULL,
         parcela_atual INTEGER NULL,
-        parcela_total INTEGER NULL
+        parcela_total INTEGER NULL,
+        categoria_id INTEGER NULL
     )');
 
-    $stmt = $pdo->prepare('INSERT INTO transacoes (date, title, amount, parcela_atual, parcela_total)
-        VALUES (:date, :title, :amount, :parcela_atual, :parcela_total)');
+    $pdo->exec('CREATE TABLE IF NOT EXISTS limites_categoria (
+        categoria_id INTEGER NOT NULL,
+        mes INTEGER NOT NULL,
+        ano INTEGER NOT NULL,
+        valor_limite REAL NOT NULL,
+        PRIMARY KEY (categoria_id, mes, ano)
+    )');
+}
+
+function insert_transaction(
+    string $date,
+    string $title,
+    float $amount,
+    ?int $parcelaAtual = null,
+    ?int $parcelaTotal = null,
+    ?int $categoriaId = null
+): void {
+    $pdo = get_pdo();
+    ensure_tables($pdo);
+
+    $stmt = $pdo->prepare('INSERT INTO transacoes (date, title, amount, parcela_atual, parcela_total, categoria_id)
+        VALUES (:date, :title, :amount, :parcela_atual, :parcela_total, :categoria_id)');
     $stmt->execute([
         ':date' => $date,
         ':title' => $title,
         ':amount' => $amount,
         ':parcela_atual' => $parcelaAtual,
         ':parcela_total' => $parcelaTotal,
+        ':categoria_id' => $categoriaId,
     ]);
+}
+
+function set_category_limit(int $categoriaId, int $mes, int $ano, float $valorLimite): void {
+    $pdo = get_pdo();
+    ensure_tables($pdo);
+    $stmt = $pdo->prepare('INSERT INTO limites_categoria (categoria_id, mes, ano, valor_limite)
+        VALUES (:categoria_id, :mes, :ano, :valor_limite)
+        ON CONFLICT(categoria_id, mes, ano) DO UPDATE SET valor_limite = :valor_limite');
+    $stmt->execute([
+        ':categoria_id' => $categoriaId,
+        ':mes' => $mes,
+        ':ano' => $ano,
+        ':valor_limite' => $valorLimite,
+    ]);
+}
+
+function get_spent_by_category(int $categoriaId, int $mes, int $ano): float {
+    $pdo = get_pdo();
+    $stmt = $pdo->prepare('SELECT SUM(amount) AS total FROM transacoes
+        WHERE categoria_id = :categoria_id
+        AND strftime("%m", date) = :mes
+        AND strftime("%Y", date) = :ano');
+    $stmt->execute([
+        ':categoria_id' => $categoriaId,
+        ':mes' => str_pad((string)$mes, 2, '0', STR_PAD_LEFT),
+        ':ano' => (string)$ano,
+    ]);
+    $total = (float)$stmt->fetchColumn();
+    return abs($total);
+}
+
+function check_limits_and_alert(int $mes, int $ano): array {
+    $pdo = get_pdo();
+    ensure_tables($pdo);
+    $stmt = $pdo->prepare('SELECT categoria_id, valor_limite FROM limites_categoria WHERE mes = :mes AND ano = :ano');
+    $stmt->execute([
+        ':mes' => $mes,
+        ':ano' => $ano,
+    ]);
+
+    $alerts = [];
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $gasto = get_spent_by_category((int)$row['categoria_id'], $mes, $ano);
+        if ($gasto > (float)$row['valor_limite']) {
+            $alerts[] = "Limite excedido para categoria {$row['categoria_id']}: gasto {$gasto} > limite {$row['valor_limite']}";
+        }
+    }
+
+    return $alerts;
 }
 
 ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/banco.php';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $categoriaId = (int)($_POST['categoria_id'] ?? 0);
+    $mes = (int)($_POST['mes'] ?? date('m'));
+    $ano = (int)($_POST['ano'] ?? date('Y'));
+    $valorLimite = (float)($_POST['valor_limite'] ?? 0);
+    set_category_limit($categoriaId, $mes, $ano, $valorLimite);
+    $message = 'Limite salvo com sucesso!';
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard - Limites por Categoria</title>
+</head>
+<body>
+<h1>Definir limite por categoria</h1>
+<?php if ($message): ?>
+    <p><?= htmlspecialchars($message) ?></p>
+<?php endif; ?>
+<form method="post">
+    <label>Categoria ID: <input type="number" name="categoria_id" required></label><br>
+    <label>Mês: <input type="number" name="mes" min="1" max="12" value="<?= date('m') ?>" required></label><br>
+    <label>Ano: <input type="number" name="ano" min="2000" value="<?= date('Y') ?>" required></label><br>
+    <label>Valor Limite: <input type="number" step="0.01" name="valor_limite" required></label><br>
+    <button type="submit">Salvar</button>
+</form>
+</body>
+</html>

--- a/rotina_diaria.php
+++ b/rotina_diaria.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/banco.php';
+
+$mes = (int)date('m');
+$ano = (int)date('Y');
+
+$alerts = check_limits_and_alert($mes, $ano);
+foreach ($alerts as $alert) {
+    echo $alert . PHP_EOL;
+}


### PR DESCRIPTION
## Summary
- create `limites_categoria` table and helper functions for limits and alerts
- add dashboard form to set monthly limits per category
- introduce daily script to warn when spending exceeds defined limits

## Testing
- `php -l banco.php`
- `php -l dashboard.php`
- `php -l rotina_diaria.php`
- `php rotina_diaria.php`

------
https://chatgpt.com/codex/tasks/task_e_689cb7062820832cbf8b36f640a6ebe7