### PR TITLE
Add SMTP email alerts when monthly limit exceeded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+*.db

--- a/config_email.php
+++ b/config_email.php
@@ -1,0 +1,7 @@
+<?php
+// Configurações de SMTP para envio de emails
+const SMTP_HOST = 'smtp.example.com';
+const SMTP_PORT = 587;
+const SMTP_USER = 'usuario@example.com';
+const SMTP_PASS = 'senha123';
+?>

--- a/email.php
+++ b/email.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/config_email.php';
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+function enviar_email(string $destinatario, string $assunto, string $corpo): bool {
+    if (!class_exists('PHPMailer\\PHPMailer\\PHPMailer')) {
+        if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+            require_once __DIR__ . '/vendor/autoload.php';
+        } else {
+            echo "Biblioteca PHPMailer não encontrada.\n";
+            return false;
+        }
+    }
+
+    try {
+        $mail = new PHPMailer(true);
+        $mail->isSMTP();
+        $mail->Host = SMTP_HOST;
+        $mail->Port = SMTP_PORT;
+        $mail->SMTPAuth = true;
+        $mail->Username = SMTP_USER;
+        $mail->Password = SMTP_PASS;
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+
+        $mail->setFrom(SMTP_USER);
+        $mail->addAddress($destinatario);
+        $mail->Subject = $assunto;
+        $mail->Body = $corpo;
+
+        return $mail->send();
+    } catch (Exception $e) {
+        echo "Erro ao enviar email: " . $e->getMessage() . "\n";
+        return false;
+    }
+}
+?>

--- a/rotina_diaria.php
+++ b/rotina_diaria.php
@@ -1,10 +1,12 @@
 <?php
 require_once __DIR__ . '/banco.php';
+require_once __DIR__ . '/email.php';
 
 $mes = (int)date('m');
 $ano = (int)date('Y');
 
 $alerts = check_limits_and_alert($mes, $ano);
 foreach ($alerts as $alert) {
+    enviar_email(SMTP_USER, 'Alerta de limite excedido', $alert);
     echo $alert . PHP_EOL;
 }


### PR DESCRIPTION
## Summary
- Add SMTP credentials configuration
- Implement PHPMailer-based `enviar_email`
- Send email alerts when category spending exceeds monthly limit

## Testing
- `php -l config_email.php`
- `php -l email.php`
- `php -l rotina_diaria.php`
- `php -r "require 'banco.php'; set_category_limit(1, (int)date('n'), (int)date('Y'), 100); insert_transaction(date('Y-m-d'), 'Compra', -150, null, null, 1);"`
- `php rotina_diaria.php` *(fails: Biblioteca PHPMailer não encontrada.)*
- `composer require phpmailer/phpmailer` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689cb8798834832ca186722e22187358