### PR TITLE
Add WhatsApp messaging service for alerts

### DIFF
--- a/config_whatsapp.php
+++ b/config_whatsapp.php
@@ -1,0 +1,6 @@
+<?php
+// Configurações do serviço de mensagens WhatsApp
+const WHATSAPP_API_URL = 'https://api.example.com/whatsapp/messages';
+const WHATSAPP_API_TOKEN = 'seu_token_aqui';
+const WHATSAPP_DEFAULT_NUMBER = '+5500000000000';
+?>

--- a/rotina_diaria.php
+++ b/rotina_diaria.php
@@ -1,6 +1,11 @@
 <?php
 require_once __DIR__ . '/banco.php';
 require_once __DIR__ . '/email.php';
+require_once __DIR__ . '/whatsapp_service.php';
+
+
+const DIA_VENCIMENTO_FATURA = 5;
+const DIAS_AVISO_FATURA = 5;
 
 $mes = (int)date('m');
 $ano = (int)date('Y');
@@ -8,5 +13,16 @@ $ano = (int)date('Y');
 $alerts = check_limits_and_alert($mes, $ano);
 foreach ($alerts as $alert) {
     enviar_email(SMTP_USER, 'Alerta de limite excedido', $alert);
+    enviar_mensagem(WHATSAPP_DEFAULT_NUMBER, $alert);
     echo $alert . PHP_EOL;
+}
+
+$diaAtual = (int)date('d');
+$diaLembrete = DIA_VENCIMENTO_FATURA - DIAS_AVISO_FATURA;
+if ($diaAtual === $diaLembrete) {
+    $dataVencimento = sprintf('%02d/%02d/%04d', DIA_VENCIMENTO_FATURA, $mes, $ano);
+    $mensagemFatura = "Lembrete: sua fatura vence em " . DIAS_AVISO_FATURA . " dias (" . $dataVencimento . ").";
+    enviar_email(SMTP_USER, 'Lembrete de fatura', $mensagemFatura);
+    enviar_mensagem(WHATSAPP_DEFAULT_NUMBER, $mensagemFatura);
+    echo $mensagemFatura . PHP_EOL;
 }

--- a/whatsapp_service.php
+++ b/whatsapp_service.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__ . '/config_whatsapp.php';
+
+/**
+ * Envia uma mensagem de texto via API do WhatsApp.
+ *
+ * @param string $numero Número de destino no formato internacional.
+ * @param string $texto  Conteúdo da mensagem.
+ * @return bool True em caso de sucesso.
+ */
+function enviar_mensagem(string $numero, string $texto): bool {
+    $payload = json_encode([
+        'to' => $numero,
+        'text' => $texto,
+    ]);
+
+    $ch = curl_init(WHATSAPP_API_URL);
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . WHATSAPP_API_TOKEN,
+        ],
+        CURLOPT_POSTFIELDS => $payload,
+    ]);
+
+    curl_exec($ch);
+    $err = curl_errno($ch);
+    $status = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($err !== 0) {
+        echo "Erro ao enviar mensagem: " . curl_strerror($err) . PHP_EOL;
+        return false;
+    }
+
+    return $status >= 200 && $status < 300;
+}
+?>


### PR DESCRIPTION
## Summary
- add WhatsApp service client with simple HTTP wrapper
- send WhatsApp alerts for spending limits and invoice reminders

## Testing
- `php -l config_whatsapp.php`
- `php -l whatsapp_service.php`
- `php -l rotina_diaria.php`


------
https://chatgpt.com/codex/tasks/task_e_689cbb127240832cb99e31d5440e3d0b