### PR TITLE
Migrate to MySQL and extend transaction imports

### DIFF
--- a/importar.php
+++ b/importar.php
@@ -6,9 +6,11 @@
  * Espera-se que o arquivo tenha as colunas: data, título e valor.
  *
  * @param string $path Caminho para o arquivo CSV.
+ * @param int $accountId ID da conta associada.
+ * @param string $tipo Tipo da transação (ex: crédito, débito).
  * @return array Lista de registros inseridos.
  */
-function parse_nubank_csv(string $path): array
+function parse_nubank_csv(string $path, int $accountId, string $tipo): array
 {
     require_once __DIR__ . '/banco.php';
 
@@ -47,23 +49,13 @@ function parse_nubank_csv(string $path): array
         }
         $valor = -abs((float)$valorLimpo);
 
-        // Detecta parcelas no título
-        $parcelaAtual = null;
-        $parcelaTotal = null;
-        if (preg_match('/Parcela\s+(\d+)\/(\d+)/i', $titulo, $matches)) {
-            $parcelaAtual = (int)$matches[1];
-            $parcelaTotal = (int)$matches[2];
-        }
-
         // Insere no banco de dados
-        insert_transaction($data, $titulo, $valor, $parcelaAtual, $parcelaTotal);
+        insert_transaction($accountId, $data, $titulo, $valor, $tipo, null, $path);
 
         $registros[] = [
             'date' => $data,
             'title' => $titulo,
             'amount' => $valor,
-            'parcela_atual' => $parcelaAtual,
-            'parcela_total' => $parcelaTotal,
         ];
     }
 

--- a/parse_fundos_pdf.py
+++ b/parse_fundos_pdf.py
@@ -80,14 +80,21 @@ def _export_csv(records: List[Record]) -> str:
     return tmp.name
 
 
-def _import_csv(csv_path: str) -> None:
+def _import_csv(csv_path: str, account_id: int, tipo: str) -> None:
     """Reuse existing PHP importer to ingest the CSV."""
     script_path = os.path.join(os.path.dirname(__file__), "importar.php")
-    php_code = f"require '{script_path}'; parse_nubank_csv('{csv_path}');"
+    php_code = (
+        f"require '{script_path}'; parse_nubank_csv('{csv_path}', {account_id}, '{tipo}');"
+    )
     subprocess.run(["php", "-r", php_code], check=True)
 
 
-def parse_fundos_pdf(pdf_path: str, run_import: bool = True) -> str:
+def parse_fundos_pdf(
+    pdf_path: str,
+    account_id: int,
+    tipo: str,
+    run_import: bool = True,
+) -> str:
     """Parse PDF of fundos and optionally import via existing flow.
 
     Returns the path to the generated temporary CSV."""
@@ -95,20 +102,27 @@ def parse_fundos_pdf(pdf_path: str, run_import: bool = True) -> str:
     records = _parse_blocks(lines)
     csv_path = _export_csv(records)
     if run_import:
-        _import_csv(csv_path)
+        _import_csv(csv_path, account_id, tipo)
     return csv_path
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Extrai transações de um PDF de fundos e reutiliza fluxo de importação."\
+        description="Extrai transações de um PDF de fundos e reutiliza fluxo de importação."
     )
     parser.add_argument("pdf", help="Caminho para o PDF do extrato de fundos.")
+    parser.add_argument("--account-id", type=int, default=0, help="ID da conta")
+    parser.add_argument("--tipo", default="desconhecido", help="Tipo da transação")
     parser.add_argument(
         "--no-import",
         action="store_true",
         help="Apenas gera o CSV temporário sem importar para o banco de dados.",
     )
     args = parser.parse_args()
-    csv_file = parse_fundos_pdf(args.pdf, run_import=not args.no_import)
+    csv_file = parse_fundos_pdf(
+        args.pdf,
+        account_id=args.account_id,
+        tipo=args.tipo,
+        run_import=not args.no_import,
+    )
     print(csv_file)

--- a/parse_nubank_credit_csv.php
+++ b/parse_nubank_credit_csv.php
@@ -4,11 +4,13 @@
  * Stub for parsing Nubank credit card CSV files.
  *
  * @param string $path Path to the CSV file.
+ * @param int $accountId Related account ID.
+ * @param string $tipo Transaction type.
  * @return array Parsed transactions (empty until implemented).
  */
-function parse_nubank_credit_csv(string $path): array
+function parse_nubank_credit_csv(string $path, int $accountId, string $tipo): array
 {
-    // TODO: Implement CSV parsing logic.
+    // TODO: Implement CSV parsing logic and call insert_transaction($accountId, ..., $tipo, null, $path).
     return [];
 }
 

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,32 @@
+CREATE TABLE accounts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(255) NOT NULL,
+    instituicao VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(255) NOT NULL,
+    categoria_pai INT NULL,
+    FOREIGN KEY (categoria_pai) REFERENCES categories(id)
+);
+
+CREATE TABLE transactions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    account_id INT NOT NULL,
+    data DATE NOT NULL,
+    descricao TEXT NOT NULL,
+    valor DECIMAL(10,2) NOT NULL,
+    tipo VARCHAR(50) NOT NULL,
+    category_id INT NULL,
+    arquivo_original TEXT NULL,
+    FOREIGN KEY (account_id) REFERENCES accounts(id),
+    FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+
+CREATE TABLE category_rules (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    palavra_chave VARCHAR(255) NOT NULL,
+    category_id INT NOT NULL,
+    FOREIGN KEY (category_id) REFERENCES categories(id)
+);


### PR DESCRIPTION
## Summary
- Switch database layer to PDO/MySQL connection and new transactions insertion API
- Pass account id and transaction type through import scripts
- Provide SQL schema for accounts, categories, transactions and rules

## Testing
- `php -l banco.php`
- `php -l importar.php`
- `php -l parse_nubank_credit_csv.php`
- `python -m py_compile parse_btg_pdf.py parse_fundos_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_689cc4fba630832c84bc6a7a4ccf6f4e