### PR TITLE
Implementa validação automática do tipo de CSV

### DIFF
--- a/importar.php
+++ b/importar.php
@@ -1,5 +1,8 @@
 <?php
 
+require_once __DIR__ . '/validador_csv.php';
+require_once __DIR__ . '/parse_nubank_credit_csv.php';
+
 /**
  * Lê um CSV exportado do Nubank e insere cada registro no banco de dados.
  *
@@ -62,6 +65,29 @@ function parse_nubank_csv(string $path, int $accountId, string $tipo): array
     fclose($handle);
 
     return $registros;
+}
+
+/**
+ * Importa um CSV identificando automaticamente o tipo do arquivo.
+ *
+ * @param string $path Caminho para o arquivo CSV.
+ * @param int    $accountId ID da conta associada.
+ * @param string $tipo Tipo da transação (ex: crédito, débito).
+ * @return array Lista de registros inseridos.
+ */
+function importar_csv(string $path, int $accountId, string $tipo): array
+{
+    $tipoArquivo = detectar_tipo_csv($path);
+
+    if ($tipoArquivo === 'conta') {
+        return parse_nubank_csv($path, $accountId, $tipo);
+    }
+
+    if ($tipoArquivo === 'cartao') {
+        return parse_nubank_credit_csv($path, $accountId, $tipo);
+    }
+
+    throw new RuntimeException('Tipo de arquivo CSV não reconhecido.');
 }
 
 ?>

--- a/validador_csv.php
+++ b/validador_csv.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Detecta o tipo de arquivo CSV com base no cabeçalho.
+ *
+ * Retorna 'conta' para arquivos de conta corrente
+ * ou 'cartao' para arquivos de cartão de crédito.
+ *
+ * @param string $path Caminho para o arquivo CSV.
+ * @return string Tipo detectado ('conta' ou 'cartao').
+ * @throws RuntimeException Se o formato não for reconhecido.
+ */
+function detectar_tipo_csv(string $path): string
+{
+    if (!file_exists($path)) {
+        throw new InvalidArgumentException("Arquivo não encontrado: {$path}");
+    }
+
+    $handle = fopen($path, 'r');
+    if ($handle === false) {
+        throw new RuntimeException("Não foi possível abrir o arquivo: {$path}");
+    }
+
+    $headers = fgetcsv($handle, 0, ',', '"', "\\");
+    fclose($handle);
+
+    if ($headers === false) {
+        throw new RuntimeException('CSV vazio ou inválido.');
+    }
+
+    $cols = array_map(function ($h) {
+        return strtolower(trim($h));
+    }, $headers);
+
+    // Arquivo padrão de conta corrente: exatamente data,titulo,valor
+    if (count($cols) === 3 && $cols[0] === 'data' && $cols[1] === 'titulo' && $cols[2] === 'valor') {
+        return 'conta';
+    }
+
+    // Arquivo de cartão de crédito: deve possuir data, valor e alguma coluna de descrição
+    $hasData  = in_array('data', $cols, true);
+    $hasValor = in_array('valor', $cols, true) || in_array('amount', $cols, true);
+    $hasDesc  = in_array('descricao', $cols, true) || in_array('descrição', $cols, true)
+        || in_array('description', $cols, true) || in_array('titulo', $cols, true) || in_array('título', $cols, true);
+
+    if ($hasData && $hasValor && $hasDesc) {
+        return 'cartao';
+    }
+
+    throw new RuntimeException('Formato de CSV não reconhecido. Verifique o cabeçalho.');
+}
+?>


### PR DESCRIPTION
## Summary
- adiciona `validador_csv.php` para identificar automaticamente o tipo de arquivo
- atualiza `importar.php` para acionar o parser correto conforme o cabeçalho

## Testing
- `php -l validador_csv.php`
- `php -l importar.php`
- `php -r "require 'validador_csv.php'; echo detectar_tipo_csv('conta.csv'), PHP_EOL;"`
- `php -r "require 'validador_csv.php'; echo detectar_tipo_csv('cartao.csv'), PHP_EOL;"`


------
https://chatgpt.com/codex/tasks/task_e_689cff872fec832c9b2946b92541d6c3